### PR TITLE
Transfer ownership to grafana/k6-core

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @grafana/k6-extensions
+* @grafana/k6-core


### PR DESCRIPTION
Replaces @grafana/k6-extensions with @grafana/k6-core in CODEOWNERS.